### PR TITLE
Fix scroll cap on long pages by pointing Lenis at <body>

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -17,6 +17,11 @@ export default function App({ Component, pageProps }) {
 
   useEffect(() => {
     const lenis = new Lenis({
+      // Observe <body>, not <html>. The site's _base.scss pins
+      // html { height: 100% } so the default content target never
+      // resizes — the scroll limit would freeze at first paint.
+      wrapper: window,
+      content: document.body,
       duration: 1.2,
       easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
       smoothWheel: true,
@@ -29,8 +34,22 @@ export default function App({ Component, pageProps }) {
     }
     rafId = requestAnimationFrame(raf);
 
+    // The LoadingScreen flips off on the next tick and the real
+    // page mounts after that. Force a resize once layout has settled
+    // so we don't sit on Lenis's 250ms debounce window.
+    const initialResize = requestAnimationFrame(() =>
+      requestAnimationFrame(() => lenis.resize())
+    );
+
+    // Final catch for the last reflow after lazy images and webfonts
+    // resolve.
+    const onLoad = () => lenis.resize();
+    window.addEventListener('load', onLoad);
+
     return () => {
+      cancelAnimationFrame(initialResize);
       cancelAnimationFrame(rafId);
+      window.removeEventListener('load', onLoad);
       lenis.destroy();
     };
   }, []);


### PR DESCRIPTION
## Summary
After PR #52 (WebP + lazy-image rollout), \`/events\` and other long, image-heavy pages stopped scrolling partway through — users could not reach the footer.

**Root cause:** \`styles/basic/_base.scss:4\` sets \`html { height: 100% }\`, pinning the \`<html>\` box to the viewport regardless of how much content overflows. Lenis 1.3.x's default \`content\` target is \`document.documentElement\` (\`<html>\`), so its internal ResizeObserver was watching an element whose size never changed. The scroll limit froze at first paint; lazy WebP cards that streamed in afterwards grew \`<body>\` but not \`<html>\`, so Lenis kept the old (tiny) limit.

**Fix:** point Lenis at \`<body>\` instead. \`_base.scss:14\` only sets \`min-height: 100%\` on body, so it grows naturally as content streams in and Lenis's internal observer fires correctly. Plus belt-and-braces:
- a double-\`requestAnimationFrame\` \`lenis.resize()\` right after init catches the LoadingScreen → real-content swap before Lenis's 250 ms internal debounce window
- a \`window.addEventListener('load', ...)\` listener catches the final reflow once webfonts and late images settle

## Why it surfaced now
The bug existed before PR #52 — but \`/events\` has 31 portfolio cards and only the first 2 are \`priority\`, so 29 lazy WebPs streaming in post-init blew through the frozen scroll limit much more visibly than before. Other pages (\`/portfolio/portfolio-list-*\`, homepage variants, all event detail pages, blog posts) were vulnerable too with smaller margins; this fix is global because \`_app.js\` wraps every page.

## Verified
- \`npm run build\` passes
- Manual: \`/events\` scrolls cleanly to the footer (user-confirmed)

## Test plan
- [ ] Scroll \`/events\` to the footer end-to-end
- [ ] Scroll \`/portfolio/portfolio-list-dark\` and \`/index-portfolio-dark\` to the footer
- [ ] Scroll one event detail page (e.g. \`/events/260427\`) to the footer
- [ ] Filter on \`/events\` (click a category pill) — confirm scroll re-clamps to the new shorter content height (no dead space, no cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)