### PR TITLE
Fix scroll cap regression with ResizeObserver on #__next

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -16,12 +16,12 @@ export default function App({ Component, pageProps }) {
   }, []);
 
   useEffect(() => {
+    // Lenis defaults: wrapper=window, content=document.documentElement.
+    // documentElement has overflow:visible, so its scrollHeight tracks
+    // the full content. We previously tried content:document.body but
+    // body has overflow-x:hidden in _base.scss which clamps body's
+    // own scrollHeight — that is what re-introduced the scroll cap.
     const lenis = new Lenis({
-      // Observe <body>, not <html>. The site's _base.scss pins
-      // html { height: 100% } so the default content target never
-      // resizes — the scroll limit would freeze at first paint.
-      wrapper: window,
-      content: document.body,
       duration: 1.2,
       easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
       smoothWheel: true,
@@ -34,22 +34,32 @@ export default function App({ Component, pageProps }) {
     }
     rafId = requestAnimationFrame(raf);
 
-    // The LoadingScreen flips off on the next tick and the real
-    // page mounts after that. Force a resize once layout has settled
-    // so we don't sit on Lenis's 250ms debounce window.
+    // Lenis's internal ResizeObserver watches the <html> *box*, which
+    // _base.scss pins to height:100% — so it never fires on content
+    // growth. We have to drive lenis.resize() ourselves.
+
+    // 1) After the LoadingScreen flips off and the real page mounts.
     const initialResize = requestAnimationFrame(() =>
       requestAnimationFrame(() => lenis.resize())
     );
 
-    // Final catch for the last reflow after lazy images and webfonts
-    // resolve.
+    // 2) After all initial-fold resources (webfonts, eager images)
+    //    settle.
     const onLoad = () => lenis.resize();
     window.addEventListener('load', onLoad);
+
+    // 3) The big one — observe the Next.js content root (#__next is
+    //    auto-height, so it grows when below-fold lazy WebPs decode).
+    //    This catches every late layout shift on long pages.
+    const nextRoot = document.getElementById('__next');
+    const ro = nextRoot ? new ResizeObserver(() => lenis.resize()) : null;
+    if (ro) ro.observe(nextRoot);
 
     return () => {
       cancelAnimationFrame(initialResize);
       cancelAnimationFrame(rafId);
       window.removeEventListener('load', onLoad);
+      if (ro) ro.disconnect();
       lenis.destroy();
     };
   }, []);


### PR DESCRIPTION
## Summary
PR #53's scroll-cap fix regressed in production. Visiting \`/events\` (and other long, image-heavy pages) on https://melting-hack.web.app stops scrolling partway through, just like before #53.

## Root cause (the previous fix's diagnosis was incomplete)

Two compounding mistakes in #53:

1. **Wrong \`content\` target.** #53 set \`content: document.body\` on the assumption that body grows with content. But \`styles/basic/_base.scss:9\` sets \`body { overflow-x: hidden }\` which (per CSS spec) flips \`overflow-y\` to \`auto\` and changes how the body's \`scrollHeight\` semantics behave. The default \`content: document.documentElement\` (\`<html>\` with \`overflow: visible\`) tracks the full document height correctly — that should not have been changed.

2. **Even with the correct \`content\` target, Lenis's internal ResizeObserver never fires** on this site. \`_base.scss:4\` pins \`html { height: 100% }\`, so the \`<html>\` element's CSS box stays at viewport height regardless of how much content overflows. \`ResizeObserver\` observes the box (border/content), not \`scrollHeight\`, so the observer fires once at init and never again. The \`requestAnimationFrame\` + \`window.load\` triggers from #53 covered initial load, but **late lazy-WebP decodes below the fold had no trigger** to drive \`lenis.resize()\`.

## Fix
\`pages/_app.js\`:
- Revert \`content\` back to Lenis's default (\`document.documentElement\`).
- Add a \`ResizeObserver\` on \`document.getElementById('__next')\`. The Next.js root is auto-height and grows naturally as content streams in, so its size changes are a reliable proxy for \"the page got taller — recompute the scroll limit.\"
- Keep the existing rAF×2 init trigger and \`window.load\` listener as belt-and-braces for the LoadingScreen → Component swap and initial-fold image settle.

This time the observer is on an element that actually changes size when content grows, so it fires for every late layout shift.

## Verified
- Build clean (\`npm run build\`)
- Manual: \`/events\` scrolls cleanly to the footer locally

## Test plan
- [ ] Scroll \`/events\` to the footer end-to-end (the page that previously capped)
- [ ] Scroll \`/portfolio/portfolio-list-dark\` and \`/index-portfolio-dark\` to the footer
- [ ] Scroll one event detail page (e.g. \`/events/260427\`) to the footer
- [ ] Filter on \`/events\` (click a category pill) — scroll re-clamps to the new shorter content height (no dead space, no cap)
- [ ] After deploy, repeat on https://melting-hack.web.app/events with DevTools throttled to Slow 4G to force a clear gap between Lenis init and lazy WebP decode

🤖 Generated with [Claude Code](https://claude.com/claude-code)